### PR TITLE
Add environment-based admin login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=secret
+# SESSION_SECRET can be set to a random string for session signing
+SESSION_SECRET=change-this-secret

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ uploads/
 # dotenv environment files
 .env
 .env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ npm start
 
 Then open [http://localhost:3000](http://localhost:3000).
 
+### Admin Login
+
+Create a `.env` file based on `.env.example` and set the admin credentials. The admin
+panel at `/admin` will redirect to `/login` until the correct username and password
+are provided.
+
 ## Test
 
 ```bash

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,3 +1,5 @@
+process.env.ADMIN_USERNAME = 'admin';
+process.env.ADMIN_PASSWORD = 'secret';
 const request = require('supertest');
 const app = require('../server');
 
@@ -6,5 +8,27 @@ describe('GET /', () => {
     const res = await request(app).get('/');
     expect(res.statusCode).toBe(200);
     expect(res.text).toContain('UGC NET Solved PYQs');
+  });
+});
+
+describe('admin authentication', () => {
+  it('redirects unauthenticated access to /login', async () => {
+    const res = await request(app).get('/admin');
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  it('allows login with correct credentials', async () => {
+    const agent = request.agent(app);
+    const loginRes = await agent
+      .post('/login')
+      .type('form')
+      .send({ username: 'admin', password: 'secret' });
+    expect(loginRes.statusCode).toBe(302);
+    expect(loginRes.headers.location).toBe('/admin');
+
+    const adminRes = await agent.get('/admin');
+    expect(adminRes.statusCode).toBe(200);
+    expect(adminRes.text).toContain('Upload Subject Resources');
   });
 });

--- a/login.html
+++ b/login.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Login</title>
+  <style>
+    body{font-family:Arial, sans-serif; max-width:400px; margin:2rem auto;}
+    label{display:block; margin-bottom:1rem;}
+    input{width:100%; padding:0.5rem;}
+    button{padding:0.5rem 1rem;}
+  </style>
+</head>
+<body>
+  <h1>Admin Login</h1>
+  <form action="/login" method="post">
+    <label>Username:
+      <input type="text" name="username" required>
+    </label>
+    <label>Password:
+      <input type="password" name="password" required>
+    </label>
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "landingpage",
       "version": "1.0.0",
       "dependencies": {
+        "dotenv": "^17.2.1",
         "express": "^4.18.2",
+        "express-session": "^1.18.2",
         "multer": "^1.4.5-lts.1"
       },
       "devDependencies": {
@@ -1850,6 +1852,18 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2106,6 +2120,40 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3703,6 +3751,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3989,6 +4046,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -4670,6 +4736,18 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.10.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test": "jest"
   },
   "dependencies": {
+    "dotenv": "^17.2.1",
     "express": "^4.18.2",
+    "express-session": "^1.18.2",
     "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Protect admin panel with session-based login that checks credentials from environment variables.
- Introduce dedicated login page and example `.env` file for configuration.
- Document admin login setup and add tests for authentication flow.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689884594bd8832bad2c4cbc676cf7fe